### PR TITLE
Change repos order in Gradle file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@
 
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
@@ -12,8 +12,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 }
 


### PR DESCRIPTION
Fixes the following build error:

>  > Could not find aapt2-proto.jar (com.android.tools.build:aapt2-proto:0.3.1).
>   Searched in the following locations:
>       https://jcenter.bintray.com/com/android/tools/build/aapt2-proto/0.3.1/aapt2-proto-0.3.1.jar

Fixes #36